### PR TITLE
Improve drop out performance by rocRAND.

### DIFF
--- a/paddle/fluid/operators/dropout_op.cu
+++ b/paddle/fluid/operators/dropout_op.cu
@@ -22,6 +22,8 @@ limitations under the License. */
 #include "paddle/fluid/operators/dropout_op.h"
 #include "paddle/fluid/platform/float16.h"
 
+#define THURST_RANDOM_LIMIT_SIZE 4000000
+
 namespace paddle {
 namespace operators {
 
@@ -48,6 +50,32 @@ __global__ void RandomGenerator(const size_t n, const int seed,
       rng.discard(step_size);
     }
     if (dist(rng) < dropout_prob) {
+      mask = static_cast<T>(0);
+    } else {
+      if (is_upscale_in_train) {
+        mask = static_cast<T>(1.0f / (1.0f - dropout_prob));
+      } else {
+        mask = static_cast<T>(1);
+      }
+    }
+    dest = s * mask;
+    mask_data[idx] = mask;
+    dst[idx] = dest;
+  }
+}
+
+template <typename T>
+__global__ void RandomGenerator(const size_t n, const int seed,
+                                const float dropout_prob, const T* src,
+                                T* mask_data, T* dst, float* random_data,
+                                bool is_upscale_in_train) {
+  int idx = blockDim.x * blockIdx.x + threadIdx.x;
+
+  T mask;
+  T dest;
+  for (; idx < n; idx += blockDim.x * gridDim.x) {
+    T s = src[idx];
+    if (random_data[idx] < dropout_prob) {
       mask = static_cast<T>(0);
     } else {
       if (is_upscale_in_train) {
@@ -90,9 +118,25 @@ class GPUDropoutKernel : public framework::OpKernel<T> {
 
       int threads = 512;
       int grid = (x->numel() + threads - 1) / threads;
-      hipLaunchKernelGGL((RandomGenerator<T>), dim3(grid), dim3(threads), 0, context.cuda_device_context().stream(), 
+#if defined(PADDLE_WITH_HIP)
+      if(size > THURST_RANDOM_LIMIT_SIZE){
+	//large size, generate random buffer one-shot to improve performance
+	framework::Tensor random;
+	auto* random_data = random.mutable_data<float>(mask->dims(), context.GetPlace());
+	hiprandGenerator_t generator = context.cuda_device_context().rand_generator();
+	PADDLE_ENFORCE(platform::dynload::hiprandSetPseudoRandomGeneratorSeed(generator, seed));
+	PADDLE_ENFORCE(platform::dynload::hiprandGenerateUniform(generator, random_data, size));
+	hipLaunchKernelGGL((RandomGenerator<T>), dim3(grid), dim3(threads), 0, context.cuda_device_context().stream(),
+	  size, seed, dropout_prob, x_data, mask_data, y_data, random_data,
+          (dropout_implementation == "upscale_in_train"));
+      } else {
+#endif
+        hipLaunchKernelGGL((RandomGenerator<T>), dim3(grid), dim3(threads), 0, context.cuda_device_context().stream(),
           size, seed, dropout_prob, x_data, mask_data, y_data,
           (dropout_implementation == "upscale_in_train"));
+#if defined(PADDLE_WITH_HIP)
+      }
+#endif
     } else {
       auto X = EigenMatrix<T>::Reshape(*x, 1);
       auto Y = EigenMatrix<T>::Reshape(*y, 1);

--- a/paddle/fluid/operators/dropout_op.h
+++ b/paddle/fluid/operators/dropout_op.h
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/platform/dynload/hiprand.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -370,6 +370,7 @@ CUDADeviceContext::CUDADeviceContext(CUDAPlace place)
   if (dynload::HasMIOpen()) {
     miopen_holder_.reset(new MiopenHolder(&stream_, place));
   }
+  hiprand_generator = nullptr;
 }
 
 CUDADeviceContext::~CUDADeviceContext() {
@@ -380,6 +381,9 @@ CUDADeviceContext::~CUDADeviceContext() {
   eigen_stream_.reset();
   eigen_device_.reset();
   PADDLE_ENFORCE(hipStreamDestroy(stream_));
+  if( hiprand_generator != nullptr ){
+    PADDLE_ENFORCE(dynload::hiprandDestroyGenerator(hiprand_generator));
+  }
 }
 
 Place CUDADeviceContext::GetPlace() const { return place_; }
@@ -415,6 +419,13 @@ MiopenWorkspaceHandle CUDADeviceContext::miopen_workspace_handle() const {
 }
 
 hipStream_t CUDADeviceContext::stream() const { return stream_; }
+
+hiprandGenerator_t CUDADeviceContext::rand_generator() const {
+  if( hiprand_generator == nullptr ){
+    PADDLE_ENFORCE(dynload::hiprandCreateGenerator((hiprandGenerator_t *)&hiprand_generator, HIPRAND_RNG_PSEUDO_DEFAULT));
+  }
+  return hiprand_generator;
+}
 
 CUDAPinnedDeviceContext::CUDAPinnedDeviceContext() {
   eigen_device_.reset(new Eigen::DefaultDevice());

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -27,6 +27,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_HIP
 #include "paddle/fluid/platform/dynload/hipblas.h"
 #include "paddle/fluid/platform/dynload/miopen.h"
+#include "paddle/fluid/platform/dynload/hiprand.h"
 #include "paddle/fluid/platform/gpu_info.h"
 #define EIGEN_USE_GPU
 #endif
@@ -405,6 +406,8 @@ class CUDADeviceContext : public DeviceContext {
   /*! \brief  Return cuda stream in the device context. */
   hipStream_t stream() const;
 
+  hiprandGenerator_t rand_generator() const;
+
   template <typename Callback>
   void RecordEvent(hipEvent_t ev, Callback callback) {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
@@ -434,6 +437,7 @@ class CUDADeviceContext : public DeviceContext {
   hipStream_t stream_;
   miopenHandle_t miopen_handle_;
   hipblasHandle_t hipblas_handle_;
+  hiprandGenerator_t hiprand_generator;
   int compute_capability;
   int multi_process;
   int max_threads_per_mp;


### PR DESCRIPTION
W/O this patch, vgg 1 card performance is 60 samples/second.
With this patch, it is 90 samples/second.