### PR TITLE
comment 2 unittest due to MIOpen doesn't support NHWC format and doub…

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1,6 +1,11 @@
 file(GLOB TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
+if(WITH_AMD_GPU)
+    list(REMOVE_ITEM TEST_OPS test_batch_norm_op)
+    list(REMOVE_ITEM TEST_OPS test_softmax_with_cross_entropy_op)
+endif()
+
 # The MKLDNN tests are skiped when the MKLDNN flag is OFF
 if(NOT WITH_MKLDNN)
     foreach(src ${TEST_OPS})


### PR DESCRIPTION
…le precision
test_batch_norm_op : MIOPEN doesn’t support NHWC format
test_softmax_with_cross_entropy_op : MIOpen doesn’t support double precision.

