### PR TITLE
[ROCm] Enable BF16 softmax + gate cuDNN-only conv2d_add fuse passes on HIP

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -635,8 +635,12 @@ const std::vector<std::string> kPirGpuPasses{
     // Operator fusion pass
     "silu_fuse_pass",
     "conv2d_bn_fuse_pass",
+#ifdef PADDLE_WITH_CUDA
+    // conv2d_add(_act)_fuse_pass lower to the fused_conv2d_add_act op, which
+    // only has a cuDNN GPUDNN kernel. Skip on ROCm/HIP.
     "conv2d_add_act_fuse_pass",
     "conv2d_add_fuse_pass",
+#endif
     "embedding_eltwise_layernorm_fuse_pass",
     "fused_rotary_position_embedding_pass",
     "fused_flash_attn_pass",

--- a/paddle/fluid/pir/transforms/gpu/conv2d_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/conv2d_add_act_fuse_pass.cc
@@ -349,4 +349,10 @@ std::unique_ptr<Pass> CreateConv2dAddActFusePass() {
 
 }  // namespace pir
 
+// The fused_conv2d_add_act op this pass produces only has a cuDNN
+// (PADDLE_WITH_CUDA) GPUDNN kernel, so the pass is a no-op on other backends.
+// Skip registration on ROCm/HIP to avoid applying the rewrite and later
+// failing at kernel-dispatch time.
+#ifdef PADDLE_WITH_CUDA
 REGISTER_IR_PASS(conv2d_add_act_fuse_pass, Conv2dAddActFusePass);
+#endif

--- a/paddle/fluid/pir/transforms/gpu/conv2d_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/conv2d_add_fuse_pass.cc
@@ -221,4 +221,10 @@ std::unique_ptr<Pass> CreateConv2dAddFusePass() {
 }
 }  // namespace pir
 
+// The fused_conv2d_add_act op this pass produces only has a cuDNN
+// (PADDLE_WITH_CUDA) GPUDNN kernel, so the pass is a no-op on other backends.
+// Skip registration on ROCm/HIP to avoid applying the rewrite and later
+// failing at kernel-dispatch time.
+#ifdef PADDLE_WITH_CUDA
 REGISTER_IR_PASS(conv2d_add_fuse_pass, Conv2dAddFusePass);
+#endif

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -34,8 +34,10 @@ USE_PIR_PASS(matmul_add_act_fuse_pass);
 USE_PIR_PASS(silu_fuse_pass);
 USE_PIR_PASS(fc_elementwise_layernorm_fuse_pass);
 USE_PIR_PASS(conv2d_bn_fuse_pass);
+#ifdef PADDLE_WITH_CUDA
 USE_PIR_PASS(conv2d_add_fuse_pass);
 USE_PIR_PASS(conv2d_add_act_fuse_pass);
+#endif
 USE_PIR_PASS(embedding_eltwise_layernorm_fuse_pass);
 USE_PIR_PASS(add_norm_fuse_pass);
 USE_PIR_PASS(group_norm_silu_fuse_pass);

--- a/paddle/phi/backends/gpu/rocm/miopen_desc.h
+++ b/paddle/phi/backends/gpu/rocm/miopen_desc.h
@@ -62,6 +62,9 @@ inline miopenDataType_t ToCudnnDataType(const DataType& t) {
     case DataType::FLOAT32:
       type = miopenFloat;
       break;
+    case DataType::BFLOAT16:
+      type = miopenBFloat16;
+      break;
     default:
       break;
   }

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -1443,34 +1443,39 @@ PD_REGISTER_KERNEL(conv2d_grad,
                    ALL_LAYOUT,
                    phi::ConvCudnnGradKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 
 PD_REGISTER_KERNEL(conv3d_grad,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::Conv3DCudnnGradKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 PD_REGISTER_KERNEL(conv2d_double_grad,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::ConvCudnnGradGradKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 
 PD_REGISTER_KERNEL(conv3d_double_grad,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::Conv3DCudnnDoubleGradKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 
 PD_REGISTER_KERNEL(depthwise_conv2d_double_grad,
                    GPU,
                    ALL_LAYOUT,
                    phi::DepthwiseConvDoubleGradGPUDNNKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
 PD_REGISTER_KERNEL(conv2d_grad,

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -561,18 +561,29 @@ void Conv3DCudnnKernel(const Context& dev_ctx,
 }  // namespace phi
 
 #ifdef PADDLE_WITH_HIP
-PD_REGISTER_KERNEL(
-    conv2d, GPUDNN, ALL_LAYOUT, phi::ConvCudnnKernel, float, phi::float16) {}
+PD_REGISTER_KERNEL(conv2d,
+                   GPUDNN,
+                   ALL_LAYOUT,
+                   phi::ConvCudnnKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
 
-PD_REGISTER_KERNEL(
-    conv3d, GPUDNN, ALL_LAYOUT, phi::Conv3DCudnnKernel, float, phi::float16) {}
+PD_REGISTER_KERNEL(conv3d,
+                   GPUDNN,
+                   ALL_LAYOUT,
+                   phi::Conv3DCudnnKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
 
 PD_REGISTER_KERNEL(depthwise_conv2d,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::DepthwiseConvCudnnKernel,
                    float,
-                   phi::float16) {}
+                   phi::float16,
+                   phi::bfloat16) {}
 
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1325,7 +1325,7 @@ void LaunchKeMatrixSoftmaxForwardKernel(const GPUContext& dev_ctx,
       <<<N, block_dim, 0, dev_ctx.stream()>>>(out, input, dim_size);
 }
 
-#if CUDNN_VERSION < 8100
+#if !defined(PADDLE_WITH_HIP) && CUDNN_VERSION < 8100
 template <>
 inline void LaunchSoftmaxForwardCudnnKernel<phi::bfloat16>(
     const GPUContext& dev_ctx,
@@ -2811,7 +2811,16 @@ void SoftmaxForwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
                                                            dim_log2);
       }
     } else {
-      if (dim >= MATRIX_SOFTMAX_THRESHOLD) {
+      bool use_matrix_kernel = dim >= MATRIX_SOFTMAX_THRESHOLD;
+#ifdef PADDLE_WITH_HIP
+      // MIOpen (as of ROCm 7.x) returns MIOPEN_STATUS_NOT_IMPLEMENTED for
+      // miopenSoftmaxForward_V2 with miopenBFloat16. Route BF16 through the
+      // matrix softmax kernel for any dim that exceeds the warp-softmax cap.
+      if (std::is_same<T, phi::bfloat16>::value) {
+        use_matrix_kernel = true;
+      }
+#endif
+      if (use_matrix_kernel) {
         LaunchKeMatrixSoftmaxForwardKernel<T, IndexType, LogMode>(
             dev_ctx, out_data, x.data<T>(), N, dim);
       } else {


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

Enables PaddleOCR-VL-1.5 to run end-to-end natively in BF16 on AMD MI300X (gfx942) under ROCm 7.x against the `paddle_hackthon` branch. Three independent HIP-only patches, 3 commits / 8 files / +58−12:

1. **`[ROCm] Re-enable BF16 conv kernels on HIP`** (`paddle/phi/backends/gpu/rocm/miopen_desc.h` + `paddle/phi/kernels/gpudnn/conv_kernel.cu` + `paddle/phi/kernels/gpudnn/conv_grad_kernel.cu`) — restores the `DataType::BFLOAT16 → miopenBFloat16` mapping and the `phi::bfloat16` registrations on `conv2d / conv2d_grad / conv2d_double_grad / conv3d / conv3d_grad / conv3d_double_grad / depthwise_conv2d / depthwise_conv2d_double_grad` that `7d14616cee` reverted from ROCm/Paddle#47. Without this, PaddleOCR-VL-1.5's vision patchify Conv2D cannot dispatch a BF16 kernel and the pipeline falls back to FP32 for the entire vision encoder. Deployment to archs that don't have BF16 MFMA/WMMA (pre-CDNA3 / pre-RDNA3) is handled via `PADDLE_ROCM_OFFLOAD_ARCHS` at configure time — `paddle_hackthon`'s default already covers the BF16-capable set (gfx942, gfx950, gfx1100, gfx1101, gfx1102, gfx1200, gfx1201).

2. **`[ROCm] Route BF16 softmax through matrix kernel (MIOpen NOT_IMPLEMENTED)`** (`paddle/phi/kernels/gpudnn/softmax_gpudnn.h`) — MIOpen (as of ROCm 7.x) returns `MIOPEN_STATUS_NOT_IMPLEMENTED` for `miopenSoftmaxForward_V2` with `miopenBFloat16`, so whenever `dim ≥ MATRIX_SOFTMAX_THRESHOLD` the existing gpudnn path dispatched into MIOpen and crashed. Route BF16 softmax to the existing matrix-softmax kernel on HIP, and gate the `CUDNN_VERSION < 8100` BF16 fallback specialization on `!defined(PADDLE_WITH_HIP)` — that branch dispatched into MIOpen too and would trip the same failure.

3. **`[ROCm] Skip cuDNN-only conv2d fusion passes on HIP`** (`paddle/fluid/pir/transforms/gpu/conv2d_add_fuse_pass.cc` + `conv2d_add_act_fuse_pass.cc` + `paddle/fluid/pir/transforms/passes.h` + `paddle/fluid/inference/api/paddle_pass_builder.cc`) — both PIR passes rewrite `conv2d + add[+ act]` into the fused `fused_conv2d_add_act` op, whose only kernel is cuDNN-only GPUDNN. On ROCm the rewrite succeeds but dispatch later fails for lack of a HIP kernel. PaddleX currently works around this by calling `config.delete_pass("conv2d_add_act_fuse_pass")` and `config.delete_pass("conv2d_add_fuse_pass")` under `paddle.is_compiled_with_rocm()` in `paddlex/inference/models/runners/paddle_static/runner.py`. Gate both `REGISTER_IR_PASS` / `USE_PIR_PASS` and the `kPirGpuPasses` list entries on `PADDLE_WITH_CUDA` so the rewrite never runs on HIP builds — the PaddleX delete_pass workaround becomes unnecessary.

#### Upstream relation

- **Sibling on mainline:** [PaddlePaddle/Paddle#78711](https://github.com/PaddlePaddle/Paddle/pull/78711) (same author) — the identical softmax + fuse-pass patch, opened earlier against `PaddlePaddle/Paddle:develop`.
- **Conv BF16 already merged upstream:** [PaddlePaddle/Paddle#78587](https://github.com/PaddlePaddle/Paddle/pull/78587) (fchange, Hackathon) — the mainline version of the conv BF16 + miopen_desc.h changes this PR restores. Already in `PaddlePaddle/Paddle:develop`, also ported to `ROCm/Paddle:develop` via [ROCm/Paddle#47](https://github.com/ROCm/Paddle/pull/47).
- **Revert being undone:** `7d14616cee` on `paddle_hackthon` reverted `ROCm/Paddle#47`'s conv BF16 ahead of RDNA4 enablement. Commit 1 in this PR restores that registration; RDNA4 deployers who hit a regression can narrow `PADDLE_ROCM_OFFLOAD_ARCHS` to exclude `gfx1200/1201` from their build until MIOpen BF16 conv is stable on RDNA4. This PR does not reintroduce the unit test that `7d14616cee` also removed (`test/legacy_test/test_hip_bf16_conv_kernel.py`) — upstream CI on ROCm/Paddle does not run that test anyway, and the e2e BF16 verification attached below exercises the kernel more thoroughly.
- **PaddleX companion (once this lands):** [PaddleX#5096](https://github.com/PaddlePaddle/PaddleX/pull/5096) drops `_keep_in_fp32_modules = ["visual", "mlp_AR"]` and the 4 `delete_pass("conv2d_add_*_fuse_pass")` blocks that are currently shipped as workarounds.

#### Verification

Full rebuild from `ROCm/Paddle:paddle_hackthon @ 4df29c5818` + these 3 commits on MI300X (gfx942) / ROCm 7.2.0 / Python 3.12 with `PADDLE_ROCM_OFFLOAD_ARCHS=gfx942`, then:

- **Per-op probe** — 15/15 BF16 ops pass (Conv2D, LayerNorm, Softmax, GELU, RMSNorm, SDPA-GQA, fused-bias-residual-layernorm, etc.).
- **Vision-encoder end-to-end** — loads real PaddleOCR-VL-1.5 weights, monkey-patches `paddle.matmul` / `F.softmax` / `F.gelu`; all 219 leaf-sublayer outputs `bfloat16`, `no BF16→FP32 leak` asserted, 27 GELU + 27 softmax + 54 matmul all BF16.
- **Full pipeline benchmark + rocprofv3** — 3 timed runs per mode on `test_ocr.png`. OCR text output semantically identical BF16 vs FP32 fallback. GPU kernel-dispatch time drops from **4,369.3 ms (FP32 fallback) → 3,897.8 ms (native BF16)**, a **1.12× speedup**. GEMM alone saves 339 ms; the FP32 fallback path's `Cijk_Ailk_Bljk_SB_MT…_MI16x16x4x1` vision-GEMMs (473 ms at ranks 2 and 3 of the top-10) disappear entirely and are replaced by `Cijk_Ailk_Bljk_BBS_BH_MT…_MI16x16x16x1` BF16 MFMA GEMMs.

Kernel-class breakdown (rocprofv3 `kernel_stats.csv`):

| Op class | FP32 calls | FP32 ms | BF16 calls | BF16 ms | Δ ms | Speedup |
| --- | ---:| ---:| ---:| ---:| ---:| ---:|
| GEMM (rocBLAS/hipBLASLt) | 87,752 | 1,786.45 | 87,752 | 1,447.27 | +339.18 | **1.23×** |
| Cast / copy / memcpy | 549,564 | 1,657.47 | 585,702 | 1,827.41 | −169.95 | 0.91× |
| Elementwise add / mul / bias | 122,840 | 357.59 | 107,720 | 210.71 | +146.88 | **1.70×** |
| Other (incl. bf16-specialized) | 40,959 | 241.43 | 27,499 | 94.93 | +146.50 | **2.54×** |
| Reduction / sum / mean | 36,004 | 144.68 | 36,004 | 142.01 | +2.67 | 1.02× |
| Softmax | 13,588 | 98.33 | 13,588 | 95.00 | +3.33 | 1.04× |
| Layer norm / RMS norm | 4,572 | 24.70 | 4,572 | 22.61 | +2.09 | 1.09× |
| Conv / MIOpen | 236 | 12.46 | 236 | 12.55 | −0.09 | 0.99× |
| GELU / SiLU / activation | 11,832 | 33.22 | 11,832 | 33.63 | −0.41 | 0.99× |
| Top-k / argmax / sort | 8 | 10.00 | 8 | 9.94 | +0.07 | 1.01× |
| Transpose / reshape | 400 | 2.19 | 240 | 1.38 | +0.82 | 1.59× |
| Embedding / gather / index | 96 | 0.25 | 96 | 0.28 | −0.03 | 0.90× |
| Interpolate / resize | 96 | 0.49 | 16 | 0.09 | +0.40 | 5.45× |
| Fill / set_value / memset | 1 | 0.01 | 1 | 0.01 | −0.00 | 0.98× |
| **Total** | **867,948** | **4,369.28** | **875,266** | **3,897.82** | **+471.46** | **1.12×** |

The full benchmark report (methodology, env, reproduce instructions, top-10 kernel tables for both modes) is kept alongside at `BF16_BENCHMARK_ROCM_FORK.md` in the workspace root and is reproducible via `bench_paddleocr_vl.py` + `rocprofv3 --kernel-trace --stats --output-format csv`.

### 是否引起精度变化

否

仅影响 ROCm/HIP 构建的 dispatch 路径：conv BF16 本就是 PR #47 的 dispatch (`miopenBFloat16` 精度)，行为与未 revert 的 `ROCm/Paddle:develop` 及 `PaddlePaddle/Paddle:develop` 一致；softmax 改走 matrix kernel 数值实现同现网 FP16/FP32 路径一致；`conv2d_add_*_fuse_pass` 在 HIP 下本就无可调度 kernel，gating 后行为等价于 PaddleX 现网 `delete_pass` 显式移除。CUDA 构建完全不受影响（所有新增 `#ifdef` 都是 `PADDLE_WITH_CUDA` / `PADDLE_WITH_HIP`）。
