### PR TITLE
[ROCm] Add native HIP BF16 conversion support

### DIFF
--- a/paddle/common/backend_header.h
+++ b/paddle/common/backend_header.h
@@ -23,6 +23,11 @@
 #include <cuda_bf16.h>
 #endif
 
+#if defined(PADDLE_WITH_HIP) && defined(__HIPCC__)
+#define PADDLE_HIP_BF16
+#include <hip/hip_bf16.h>
+#endif
+
 #ifndef PADDLE_WITH_HIP
 #if !defined(_WIN32)
 #define PADDLE_ALIGN(x) __attribute__((aligned(x)))

--- a/paddle/phi/common/bfloat16.h
+++ b/paddle/phi/common/bfloat16.h
@@ -82,23 +82,22 @@ struct PADDLE_ALIGN(2) bfloat16 {
   ~bfloat16() = default;
 
   HOSTDEVICE inline explicit bfloat16(float val) {
-#ifdef PADDLE_WITH_HIP
-    uint32_t res = 0;
-    uint32_t* tempRes;
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    tempRes = reinterpret_cast<uint32_t*>(&val);
-    res = *tempRes;
-    x = res >> 16;
-#else
-#if defined(PADDLE_CUDA_BF16)
+#if defined(PADDLE_HIP_BF16)
+    __hip_bfloat16 tmp = __float2bfloat16(val);
+    x = *reinterpret_cast<uint16_t*>(&tmp);
+#elif defined(PADDLE_CUDA_BF16)
     __nv_bfloat16 tmp = __float2bfloat16(val);
     x = *reinterpret_cast<uint16_t*>(&tmp);
 #else
     x = cpu_float_to_bfloat16(val);
 #endif
-#endif
   }
+
+#if defined(PADDLE_HIP_BF16)
+  HOSTDEVICE inline explicit bfloat16(const __hip_bfloat16& val) {
+    x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
+  }
+#endif
 
 #if defined(PADDLE_CUDA_BF16)
   HOSTDEVICE inline explicit bfloat16(const __nv_bfloat16& val) {
@@ -111,6 +110,13 @@ struct PADDLE_ALIGN(2) bfloat16 {
       : x(bfloat16(static_cast<float>(val)).x) {}
 
 // Assignment operators
+#if defined(PADDLE_HIP_BF16)
+  HOSTDEVICE inline bfloat16& operator=(const __hip_bfloat16& val) {
+    x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
+    return *this;
+  }
+#endif
+
 #if defined(PADDLE_CUDA_BF16)
   HOSTDEVICE inline bfloat16& operator=(const __nv_bfloat16& val) {
     x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
@@ -175,18 +181,9 @@ struct PADDLE_ALIGN(2) bfloat16 {
 
   // Conversion operators
   HOSTDEVICE inline operator float() const {
-#ifdef PADDLE_WITH_HIP
-    uint32_t res = 0;
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    uint16_t temp = x;
-    uint16_t* temp_ptr = reinterpret_cast<uint16_t*>(&temp);
-    res = *temp_ptr;
-    // return res;
-    res = res << 16;
-    return *reinterpret_cast<float*>(&res);
-#else
-#ifdef PADDLE_CUDA_BF16
+#if defined(PADDLE_HIP_BF16)
+    return __bfloat162float(*reinterpret_cast<const __hip_bfloat16*>(&x));
+#elif defined(PADDLE_CUDA_BF16)
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
 #else
     float val = 0.f;
@@ -195,8 +192,13 @@ struct PADDLE_ALIGN(2) bfloat16 {
         reinterpret_cast<char*>(&val) + 2, reinterpret_cast<char*>(&temp), 2);
     return val;
 #endif
-#endif
   }
+
+#ifdef PADDLE_HIP_BF16
+  HOSTDEVICE inline __hip_bfloat16 to_hip_bfloat16() const {
+    return *reinterpret_cast<const __hip_bfloat16*>(&x);
+  }
+#endif
 
 #ifdef PADDLE_CUDA_BF16
   HOSTDEVICE inline __nv_bfloat16 to_nv_bfloat16() const {

--- a/paddle/phi/common/datatype_traits.h
+++ b/paddle/phi/common/datatype_traits.h
@@ -32,7 +32,13 @@ struct PDDataTypeTraits<phi::dtype::float16> {
   using DataType = half;
 };
 
-#ifdef PADDLE_CUDA_BF16
+#if defined(PADDLE_HIP_BF16)
+template <>
+class PDDataTypeTraits<phi::dtype::bfloat16> {
+ public:
+  using DataType = __hip_bfloat16;
+};
+#elif defined(PADDLE_CUDA_BF16)
 template <>
 class PDDataTypeTraits<phi::dtype::bfloat16> {
  public:

--- a/test/cpp/fluid/platform/bfloat16_test.cc
+++ b/test/cpp/fluid/platform/bfloat16_test.cc
@@ -11,6 +11,9 @@ limitations under the License. */
 
 #include "paddle/phi/common/bfloat16.h"
 
+#include <cstdint>
+#include <cstring>
+
 #include "paddle/phi/kernels/funcs/eigen/extensions.h"
 
 #include "gtest/gtest.h"
@@ -21,6 +24,16 @@ namespace paddle::platform {
 
 using bfloat16 = phi::dtype::bfloat16;
 using namespace phi::dtype;  // NOLINT
+
+namespace {
+
+float FloatFromBits(uint32_t bits) {
+  float value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+}  // namespace
 
 TEST(bfloat16, conversion_cpu) {
   // Conversion from float
@@ -68,6 +81,13 @@ TEST(bfloat16, conversion_cpu) {
   EXPECT_NEAR(static_cast<double>(bfloat16(0.33333)), 0.33333, 0.01);
   EXPECT_EQ(static_cast<int>(bfloat16(-1)), -1);
   EXPECT_EQ(static_cast<bool>(bfloat16(true)), true);
+}
+
+TEST(bfloat16, round_to_nearest_even_cpu) {
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f808000)).x, 0x3f80);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f818000)).x, 0x3f82);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f817fff)).x, 0x3f81);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f818001)).x, 0x3f82);
 }
 
 TEST(bfloat16, arithmetic_cpu) {

--- a/test/cpp/fluid/platform/bfloat16_test.cu
+++ b/test/cpp/fluid/platform/bfloat16_test.cu
@@ -17,16 +17,28 @@ limitations under the License. */
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 
 #include "paddle/fluid/framework/lod_tensor.h"
 
-#if defined(PADDLE_CUDA_BF16)
+#if defined(PADDLE_CUDA_BF16) || defined(PADDLE_HIP_BF16)
 namespace paddle {
 namespace platform {
 
 using bfloat16 = phi::dtype::bfloat16;
 using namespace phi::dtype;  // NOLINT
+
+namespace {
+
+float FloatFromBits(uint32_t bits) {
+  float value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+}  // namespace
 
 TEST(bfloat16, convert_float32_to_bfloat16_on_gpu) {
   // Convert float32 to bfloat16
@@ -38,10 +50,21 @@ TEST(bfloat16, convert_float32_to_bfloat16_on_gpu) {
   EXPECT_EQ((bfloat16(65536.0f)).x, 0x4780);
 }
 
+TEST(bfloat16, round_to_nearest_even_on_gpu) {
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f808000)).x, 0x3f80);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f818000)).x, 0x3f82);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f817fff)).x, 0x3f81);
+  EXPECT_EQ(bfloat16(FloatFromBits(0x3f818001)).x, 0x3f82);
+}
+
 TEST(bfloat16, assignment_operator_on_gpu) {
   // Assignment operator
   bfloat16 v_assign;
+#if defined(PADDLE_HIP_BF16)
+  v_assign = bfloat16(1.0f).to_hip_bfloat16();
+#else
   v_assign = bfloat16(1.0f).to_nv_bfloat16();
+#endif
   EXPECT_EQ(v_assign.x, 0x3f80);
   v_assign = 0.33333;
   EXPECT_EQ(v_assign.x, 0x3eab);


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
该 PR 完善 ROCm 下 `phi::bfloat16` 的基础类型支持，避免 HIP 构建中 float 转 BF16 走简单截断路径。

主要改动：
- 在 HIP 编译路径下引入 `hip/hip_bf16.h`，定义 `PADDLE_HIP_BF16`。
- 为 `phi::dtype::bfloat16` 增加 `__hip_bfloat16` 构造、赋值和 `to_hip_bfloat16()` 转换。
- HIP native 路径使用 HIP BF16 转换接口，保持 round-to-nearest-even 行为；非 native 路径继续使用 CPU 一致的转换逻辑。
- 将 `PDDataTypeTraits<phi::dtype::bfloat16>` 在 HIP native 路径映射到 `__hip_bfloat16`。
- 扩展 BF16 CPU/GPU 测试，覆盖 RNE tie case 和 HIP native round-trip。

本地验证：
- `git diff --check`
- host BF16 RNE 临时编译/运行探针通过
- `PADDLE_WITH_HIP` host fallback 临时编译探针通过
- HIP BF16 native RNE/round-trip 临时编译/运行探针通过
- `datatype_traits.h` HIP syntax-only 临时探针通过

限制：当前环境没有完整 `build/` 目录，`third_party/glog` 未展开，且 `prek`/`pre-commit`/`clang-format` 不在 PATH，因此未能运行完整 CMake 单测和 `prek`。

### 是否引起精度变化
是

该 PR 修复 ROCm 下 float 转 BF16 的舍入语义：原先 HIP 路径会截断，现在与 CPU/CUDA 一样使用 round-to-nearest-even。已有依赖错误截断结果的极端 bit-level case 可能发生变化，但这是 BF16 转换语义修正。
