### PR TITLE
[ROCm] Use native HIP BF16 rounding in phi bfloat16

### DIFF
--- a/paddle/common/backend_header.h
+++ b/paddle/common/backend_header.h
@@ -23,6 +23,11 @@
 #include <cuda_bf16.h>
 #endif
 
+#if defined(PADDLE_WITH_HIP) && defined(__HIPCC__)
+#define PADDLE_HIP_BF16
+#include <hip/hip_bfloat16.h>
+#endif
+
 #ifndef PADDLE_WITH_HIP
 #if !defined(_WIN32)
 #define PADDLE_ALIGN(x) __attribute__((aligned(x)))

--- a/paddle/phi/common/bfloat16.h
+++ b/paddle/phi/common/bfloat16.h
@@ -82,21 +82,14 @@ struct PADDLE_ALIGN(2) bfloat16 {
   ~bfloat16() = default;
 
   HOSTDEVICE inline explicit bfloat16(float val) {
-#ifdef PADDLE_WITH_HIP
-    uint32_t res = 0;
-    uint32_t* tempRes;
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    tempRes = reinterpret_cast<uint32_t*>(&val);
-    res = *tempRes;
-    x = res >> 16;
-#else
 #if defined(PADDLE_CUDA_BF16)
     __nv_bfloat16 tmp = __float2bfloat16(val);
     x = *reinterpret_cast<uint16_t*>(&tmp);
+#elif defined(PADDLE_HIP_BF16)
+    hip_bfloat16 tmp(val);
+    x = tmp.data;
 #else
     x = cpu_float_to_bfloat16(val);
-#endif
 #endif
   }
 
@@ -104,6 +97,10 @@ struct PADDLE_ALIGN(2) bfloat16 {
   HOSTDEVICE inline explicit bfloat16(const __nv_bfloat16& val) {
     x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
   }
+#endif
+
+#if defined(PADDLE_HIP_BF16)
+  HOSTDEVICE inline explicit bfloat16(const hip_bfloat16& val) { x = val.data; }
 #endif
 
   template <class T>
@@ -114,6 +111,13 @@ struct PADDLE_ALIGN(2) bfloat16 {
 #if defined(PADDLE_CUDA_BF16)
   HOSTDEVICE inline bfloat16& operator=(const __nv_bfloat16& val) {
     x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
+    return *this;
+  }
+#endif
+
+#if defined(PADDLE_HIP_BF16)
+  HOSTDEVICE inline bfloat16& operator=(const hip_bfloat16& val) {
+    x = val.data;
     return *this;
   }
 #endif
@@ -175,19 +179,10 @@ struct PADDLE_ALIGN(2) bfloat16 {
 
   // Conversion operators
   HOSTDEVICE inline operator float() const {
-#ifdef PADDLE_WITH_HIP
-    uint32_t res = 0;
-    // We should be using memcpy in order to respect the strict aliasing rule
-    // but it fails in the HIP environment.
-    uint16_t temp = x;
-    uint16_t* temp_ptr = reinterpret_cast<uint16_t*>(&temp);
-    res = *temp_ptr;
-    // return res;
-    res = res << 16;
-    return *reinterpret_cast<float*>(&res);
-#else
-#ifdef PADDLE_CUDA_BF16
+#if defined(PADDLE_CUDA_BF16)
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
+#elif defined(PADDLE_HIP_BF16)
+    return static_cast<float>(to_hip_bfloat16());
 #else
     float val = 0.f;
     uint16_t temp = x;
@@ -195,12 +190,19 @@ struct PADDLE_ALIGN(2) bfloat16 {
         reinterpret_cast<char*>(&val) + 2, reinterpret_cast<char*>(&temp), 2);
     return val;
 #endif
-#endif
   }
 
 #ifdef PADDLE_CUDA_BF16
   HOSTDEVICE inline __nv_bfloat16 to_nv_bfloat16() const {
     return *reinterpret_cast<const __nv_bfloat16*>(&x);
+  }
+#endif
+
+#ifdef PADDLE_HIP_BF16
+  HOSTDEVICE inline hip_bfloat16 to_hip_bfloat16() const {
+    hip_bfloat16 val;
+    val.data = x;
+    return val;
   }
 #endif
 


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
当前 HIP 构建下 `phi::dtype::bfloat16` 从 float 构造时直接截断高 16 bit，和 CUDA/CPU 路径的 round-to-nearest-even 行为不一致，导致 `bfloat16_test` 中的 bit 级转换检查失败。

本 PR 为 HIP 编译器环境启用 `hip_bfloat16` 头文件和 `PADDLE_HIP_BF16` 宏，并在 `phi::dtype::bfloat16` 中补齐 `hip_bfloat16` 构造、赋值和 `to_hip_bfloat16` 转换桥接。HIP 编译器路径使用 `hip_bfloat16` 的 native rounding；普通 host C++ 编译路径继续复用已有 CPU round-to-nearest-even fallback，避免 host-only 编译单元强依赖 HIP native 类型。

### 是否引起精度变化
否。该修复统一 BF16 bit 级转换舍入行为，不改变既有 FP32 计算语义。

### Test
- `prek run --files paddle/common/backend_header.h paddle/phi/common/bfloat16.h`
- `env TARGET=SKYLAKEX ninja -j 160 bfloat16_test`
- `./test/cpp/bfloat16_test`
