### PR TITLE
[ROCm] Enable BF16 top-p sampling kernel

### DIFF
--- a/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_p_sampling_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/top_p_sampling_kernel.h"
 
 #ifdef PADDLE_WITH_HIP
+#include <hip/hip_bfloat16.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <hiprand_kernel.h>
@@ -27,6 +28,9 @@
 #if defined(__CUDACC__) && CUDA_VERSION >= 11060
 #define CUDA_BFLOAT16_AVAILABLE
 #include <cuda_bf16.h>
+#endif
+#if defined(PADDLE_WITH_HIP) && HIP_VERSION >= 60100000
+#define HIP_BFLOAT16_AVAILABLE
 #endif
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
@@ -62,6 +66,13 @@ struct DataTypeTraits<phi::float16> {
 template <>
 struct DataTypeTraits<phi::bfloat16> {
   using DataType = __nv_bfloat16;
+};
+#endif
+
+#ifdef HIP_BFLOAT16_AVAILABLE
+template <>
+struct DataTypeTraits<phi::bfloat16> {
+  using DataType = hip_bfloat16;
 };
 #endif
 
@@ -1260,7 +1271,7 @@ void TopPSamplingKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-#ifdef CUDA_BFLOAT16_AVAILABLE
+#if defined(CUDA_BFLOAT16_AVAILABLE) || defined(HIP_BFLOAT16_AVAILABLE)
 PD_REGISTER_KERNEL(top_p_sampling,
                    GPU,
                    ALL_LAYOUT,

--- a/test/legacy_test/test_top_p_sampling.py
+++ b/test/legacy_test/test_top_p_sampling.py
@@ -173,5 +173,31 @@ class TestTopPAPI(unittest.TestCase):
                 self.run_static(place)
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    or not core.is_bfloat16_supported(get_device_place()),
+    "core is not compiled with CUDA or not support bfloat16",
+)
+class TestTopPAPIBF16(unittest.TestCase):
+    def test_dygraph_bfloat16(self):
+        with paddle.base.dygraph.guard(get_device_place()):
+            input_tensor = paddle.to_tensor(
+                [[0.6, 0.3, 0.1], [0.2, 0.5, 0.3]], dtype="float32"
+            ).astype("bfloat16")
+            topp_tensor = paddle.to_tensor(
+                [[0.8], [0.8]], dtype="float32"
+            ).astype("bfloat16")
+
+            out, ids = paddle.tensor.top_p_sampling(
+                input_tensor, topp_tensor, seed=2023
+            )
+
+            self.assertEqual(out.dtype, paddle.bfloat16)
+            self.assertEqual(ids.dtype, paddle.int64)
+            self.assertEqual(out.shape, [2, 1])
+            self.assertEqual(ids.shape, [2, 1])
+            ids.numpy()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
Enable BF16 support for the ROCm top_p_sampling GPU kernel.

This PR:
- Maps phi::bfloat16 to hip_bfloat16 for HIP radix sort keys when HIP_VERSION >= 60100000.
- Registers the top_p_sampling BF16 GPU kernel on ROCm when HIP BF16 is available.
- Adds focused dygraph BF16 coverage for top_p_sampling.

Verification:
- env TARGET=SKYLAKEX ninja -j 160 paddle_python
- BF16 top_p_sampling repro on ROCm GPU
- python3.12 -m unittest test_top_p_sampling.TestTopPAPIBF16
- python3.12 test_top_p_sampling.py
- prek run --files paddle/phi/kernels/gpu/top_p_sampling_kernel.cu test/legacy_test/test_top_p_sampling.py
- git diff --check

### 是否引起精度变化
否