### PR TITLE
[ROCm] Add CINN HIP BF16 codegen support

### DIFF
--- a/paddle/cinn/backends/hip/codegen_hip_dev.cc
+++ b/paddle/cinn/backends/hip/codegen_hip_dev.cc
@@ -20,7 +20,12 @@ namespace hip {
 
 const std::string CodeGenHipDevice::source_header_ =  // NOLINT
     R"(#define CINN_WITH_HIP
+     #include "bfloat16.h"
      #include "float16.h"
+     using cinn::common::bfloat16;
+     using cinn::common::bfloat168;
+     using cinn::common::bfloat164;
+     using cinn::common::bfloat162;
      using cinn::common::float16;
      #include "cinn_hip_runtime_source.h"
 )";

--- a/paddle/cinn/common/bfloat16.h
+++ b/paddle/cinn/common/bfloat16.h
@@ -34,6 +34,15 @@
 #endif  // __CUDACC__
 #endif  // CINN_WITH_CUDA
 
+#ifdef CINN_WITH_HIP
+#include <hip/hip_runtime.h>
+#if defined(__HIPCC__) && HIP_VERSION >= 60100000
+#define __HIP_PLATFORM_AMD__
+#include <hip/hip_bfloat16.h>
+#define CINN_HIP_BF16
+#endif
+#endif  // CINN_WITH_HIP
+
 #ifdef __cplusplus
 
 #ifndef _WIN32
@@ -80,6 +89,9 @@ struct CINN_ALIGN(2) bfloat16 {
 #if defined(CINN_CUDA_BF16)
     __nv_bfloat16 tmp = __float2bfloat16(val);
     x = *reinterpret_cast<uint16_t*>(&tmp);
+#elif defined(CINN_HIP_BF16)
+    hip_bfloat16 tmp(val);
+    x = *reinterpret_cast<uint16_t*>(&tmp);
 #else
     std::memcpy(&x, reinterpret_cast<char*>(&val) + 2, 2);
 #endif
@@ -91,6 +103,12 @@ struct CINN_ALIGN(2) bfloat16 {
   }
 #endif
 
+#if defined(CINN_HIP_BF16)
+  __host__ __device__ inline explicit bfloat16(const hip_bfloat16& val) {
+    x = *reinterpret_cast<const uint16_t*>(&val);
+  }
+#endif
+
   template <class T>
   __host__ __device__ inline explicit bfloat16(const T& val)
       : x(bfloat16(static_cast<float>(val)).x) {}
@@ -99,6 +117,13 @@ struct CINN_ALIGN(2) bfloat16 {
 #if defined(CINN_CUDA_BF16)
   __host__ __device__ inline bfloat16& operator=(const __nv_bfloat16& val) {
     x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
+    return *this;
+  }
+#endif
+
+#if defined(CINN_HIP_BF16)
+  __host__ __device__ inline bfloat16& operator=(const hip_bfloat16& val) {
+    x = *reinterpret_cast<const uint16_t*>(&val);
     return *this;
   }
 #endif
@@ -162,6 +187,8 @@ struct CINN_ALIGN(2) bfloat16 {
   __host__ __device__ inline operator float() const {
 #ifdef CINN_CUDA_BF16
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));
+#elif defined(CINN_HIP_BF16)
+    return static_cast<float>(*reinterpret_cast<const hip_bfloat16*>(&x));
 #else
     float val = 0.f;
     uint16_t temp = x;
@@ -174,6 +201,12 @@ struct CINN_ALIGN(2) bfloat16 {
 #ifdef CINN_CUDA_BF16
   __host__ __device__ inline __nv_bfloat16 to_nv_bfloat16() const {
     return *reinterpret_cast<const __nv_bfloat16*>(&x);
+  }
+#endif
+
+#ifdef CINN_HIP_BF16
+  __host__ __device__ inline hip_bfloat16 to_hip_bfloat16() const {
+    return *reinterpret_cast<const hip_bfloat16*>(&x);
   }
 #endif
 

--- a/test/cpp/pir/cinn/compilation_task_test.cc
+++ b/test/cpp/pir/cinn/compilation_task_test.cc
@@ -26,6 +26,9 @@
 #include "paddle/cinn/hlir/framework/pir/compilation_task.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
+#ifdef PADDLE_WITH_HIP
+#include "paddle/cinn/backends/hip/codegen_hip_dev.h"
+#endif
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_api.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
@@ -38,6 +41,19 @@ using cinn::hlir::framework::pir::OpLoweringGroupPtr;
 
 using ProgramInfo = std::tuple<std::shared_ptr<::pir::Program>,
                                std::vector<OpLoweringGroupPtr>>;
+#ifdef PADDLE_WITH_HIP
+TEST(CodeGenHipDevice, SourceHeaderIncludesBfloat16) {
+  const std::string& header =
+      cinn::backends::hip::CodeGenHipDevice::GetSourceHeader();
+
+  EXPECT_NE(header.find("#include \"bfloat16.h\""), std::string::npos);
+  EXPECT_NE(header.find("using cinn::common::bfloat16;"), std::string::npos);
+  EXPECT_NE(header.find("using cinn::common::bfloat168;"), std::string::npos);
+  EXPECT_NE(header.find("using cinn::common::bfloat164;"), std::string::npos);
+  EXPECT_NE(header.find("using cinn::common::bfloat162;"), std::string::npos);
+}
+#endif
+
 ProgramInfo BuildProgram(std::vector<int64_t> input_shape) {
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
Add BF16 type support to CINN HIP device code generation.

This PR:
- Includes bfloat16.h in the HIP device source header and exports CINN bfloat16 vector aliases.
- Adds a CINN_WITH_HIP branch in cinn/common/bfloat16.h that uses ROCm hip_bfloat16 for device-side float/BF16 conversion when HIP_VERSION >= 60100000.
- Adds a ROCm-guarded header coverage check in the CINN compilation task test source.

Verification:
- cmake .
- env TARGET=SKYLAKEX ninja -j 160 paddle_python
- HIPCC compile test for CINN_WITH_HIP bfloat16 construction, conversion, and to_hip_bfloat16 on gfx942
- prek run --files paddle/cinn/backends/hip/codegen_hip_dev.cc paddle/cinn/common/bfloat16.h test/cpp/pir/cinn/compilation_task_test.cc
- git diff --check

Note: the current local build configuration does not generate test_compilation_task in CTest (ctest -N -R test_compilation_task reports 0 tests), so the added gtest is covered when CINN tests are enabled.

### 是否引起精度变化
否